### PR TITLE
Correction of JBossModulesAT Documentation link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ and the commits of this project :  [JBossModulesAT commits](https://github.com/k
 
 Here are the screenshots of successful runs of JBossModulesAT for different versions : [JBossModulesAT Screenshots](https://www.dropbox.com/sh/rcak1agnaozv6br/AADrGTjmqbVbzaXsGTxXzZX7a?dl=0)
 
-The documentation of this project can be found in the README.md file of the JBossModulesAT github repo : [JBossModulesAT Documentation](https://github.com/jboss-set/eap-additional-testsuite/blob/master/README.md) 
+The documentation of this project can be found in the README.md file of the JBossModulesAT github repo :  [JBossModulesAT Documentation](https://github.com/koderproxy/JBossModulesAT/blob/master/README.md)
 
 [JBossModulesAT](https://github.com/koderproxy/JBossModulesAT)  has been also included in the [workshop](https://www.dropbox.com/s/bebhyd1iz7cg1i2/EAT_WORKSHOP.odt?dl=0)
 


### PR DESCRIPTION
The link should be :  [JBossModulesAT Documentation](https://github.com/koderproxy/JBossModulesAT/blob/master/README.md) 